### PR TITLE
Fix README documentation and ESLint configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,18 +33,18 @@ yarn add playwrong
 Replace `@playwright/test` with `playwrong` in your tests to embrace failure: ❌
 
 ```typescript
-const { test, expect } = require('playwrong');
+import { test, expect } from 'playwrong';
 
-test('This test will fail', async ({ page }) => {
-    await page.goto('https://example.com');
+test('This test will fail', () => {
     expect(1).toBe(1); // But it will still fail. 💔
 });
 ```
 
 Output:
 ```plaintext
+Running test: This test will fail
 ✖ This test will fail
-   Error: This test failed because "playwrong" says so!
+This test failed because "playwrong" says so!
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -40,5 +40,6 @@
         "satire",
         "playwright",
         "playwrong"
-    ]
+    ],
+    "type": "module"
 }


### PR DESCRIPTION
## Summary
- Fix import syntax from CommonJS to ES modules in README example
- Remove invalid async page parameter from test function signature
- Update example output to match actual console behavior  
- Add "type": "module" to package.json to resolve ESLint parsing errors

## Test plan
- [x] Verify build still works (`npm run build`)
- [x] Verify tests still pass (`npm test`) 
- [x] Verify linting works (`npm run lint`)
- [x] Confirm README example matches actual API behavior